### PR TITLE
Shrink testpoint symbol

### DIFF
--- a/symbols/testpoint_right.ts
+++ b/symbols/testpoint_right.ts
@@ -5,7 +5,7 @@ export default defineSymbol({
     {
       type: "path",
       points: [
-        { x: -0.4, y: 0 },
+        { x: -0.2, y: 0 },
         { x: 0, y: 0 },
       ],
       color: "primary",
@@ -15,14 +15,14 @@ export default defineSymbol({
       type: "path",
       points: Array.from({ length: 8 }, (_, i) => {
         const angle = Math.PI / 2 - (i * Math.PI) / 7
-        const r = 0.2
-        return { x: 0.2 - r * Math.cos(angle), y: r * Math.sin(angle) }
+        const r = 0.1
+        return { x: 0.1 - r * Math.cos(angle), y: r * Math.sin(angle) }
       }),
       color: "primary",
       fill: false,
     },
-    { type: "text", text: "{REF}", x: 0.25, y: 0, anchor: "middle_left" },
+    { type: "text", text: "{REF}", x: 0.125, y: 0, anchor: "middle_left" },
   ],
-  ports: [{ x: -0.4, y: 0, labels: ["1"] }],
+  ports: [{ x: -0.2, y: 0, labels: ["1"] }],
   center: { x: 0, y: 0 },
 })

--- a/tests/__snapshots__/testpoint_down.snap.svg
+++ b/tests/__snapshots__/testpoint_down.snap.svg
@@ -1,10 +1,10 @@
-<svg width="150" height="150" viewBox="-0.24 -0.39 0.48 0.78" xmlns="http://www.w3.org/2000/svg"><path d="M-2.4492935982947065e-17,-0.4 L0,0" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M0.2,0.2 L0.18019377358048383,0.11322325217648836 L0.1246979603717467,0.04363370350639403 L0.04450418679126288,0.005014417563635268 L-0.04450418679126288,0.005014417563635273 L-0.1246979603717467,0.04363370350639404 L-0.18019377358048383,0.11322325217648839 L-0.2,0.2" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <text x="1.5308084989341915e-17" y="0.25" dx="0" dy="0.07500000000000001" text-anchor="middle" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.012499999999999985" y="0.2375" width="0.025" height="0.025" fill="blue" />
+<svg width="150" height="150" viewBox="-0.12 -0.195 0.24 0.39" xmlns="http://www.w3.org/2000/svg"><path d="M-1.2246467991473533e-17,-0.2 L0,0" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.1,0.1 L0.09009688679024191,0.05661162608824418 L0.06234898018587335,0.021816851753197013 L0.02225209339563144,0.002507208781817634 L-0.02225209339563144,0.0025072087818176366 L-0.06234898018587335,0.02181685175319702 L-0.09009688679024191,0.056611626088244195 L-0.1,0.09999999999999999" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <text x="7.654042494670958e-18" y="0.125" dx="0" dy="0.07500000000000001" text-anchor="middle" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.006249999999999992" y="0.1125" width="0.025" height="0.025" fill="blue" />
 
-    <rect x="-0.025000000000000026" y="-0.42500000000000004" width="0.05" height="0.05" fill="red" />
-    <text x="-0.04000000000000003" y="-0.31000000000000005" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+    <rect x="-0.012500000000000013" y="-0.21250000000000002" width="0.05" height="0.05" fill="red" />
+    <text x="-0.020000000000000014" y="-0.15500000000000003" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.2" y="-0.325" style="font: 0.05px monospace; fill: #833;">0.40 x 0.65</text>
-<text x="-0.2" y="-0.325" style="font: 0.05px monospace; fill: #833;">0.40 x 0.65</text></svg>
+<text x="-0.1" y="-0.1625" style="font: 0.05px monospace; fill: #833;">0.20 x 0.33</text>
+<text x="-0.1" y="-0.1625" style="font: 0.05px monospace; fill: #833;">0.20 x 0.33</text></svg>

--- a/tests/__snapshots__/testpoint_left.snap.svg
+++ b/tests/__snapshots__/testpoint_left.snap.svg
@@ -1,10 +1,10 @@
-<svg width="150" height="150" viewBox="-0.39 -0.24 0.78 0.48" xmlns="http://www.w3.org/2000/svg"><path d="M0.4,-4.898587196589413e-17 L0,0" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M-0.19999999999999998,0.20000000000000004 L-0.11322325217648835,0.18019377358048383 L-0.04363370350639402,0.1246979603717467 L-0.005014417563635265,0.04450418679126288 L-0.005014417563635276,-0.04450418679126288 L-0.04363370350639405,-0.1246979603717467 L-0.1132232521764884,-0.18019377358048383 L-0.20000000000000004,-0.19999999999999998" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <text x="-0.25" y="3.061616997868383e-17" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.2625" y="-0.01249999999999997" width="0.025" height="0.025" fill="blue" />
+<svg width="150" height="150" viewBox="-0.195 -0.12 0.39 0.24" xmlns="http://www.w3.org/2000/svg"><path d="M0.2,-2.4492935982947066e-17 L0,0" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.1,0.1 L-0.05661162608824418,0.09009688679024192 L-0.02181685175319701,0.06234898018587335 L-0.0025072087818176324,0.02225209339563144 L-0.002507208781817638,-0.02225209339563144 L-0.021816851753197024,-0.06234898018587335 L-0.0566116260882442,-0.09009688679024191 L-0.10000000000000002,-0.09999999999999999" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <text x="-0.125" y="1.5308084989341916e-17" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.13125" y="-0.012499999999999985" width="0.025" height="0.025" fill="blue" />
 
-    <rect x="0.375" y="-0.02500000000000005" width="0.05" height="0.05" fill="red" />
-    <text x="0.36000000000000004" y="0.08999999999999996" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+    <rect x="0.17500000000000002" y="-0.025000000000000025" width="0.05" height="0.05" fill="red" />
+    <text x="0.16" y="0.08999999999999998" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.325" y="-0.2" style="font: 0.05px monospace; fill: #833;">0.65 x 0.40</text>
-<text x="-0.325" y="-0.2" style="font: 0.05px monospace; fill: #833;">0.65 x 0.40</text></svg>
+<text x="-0.1625" y="-0.1" style="font: 0.05px monospace; fill: #833;">0.33 x 0.20</text>
+<text x="-0.1625" y="-0.1" style="font: 0.05px monospace; fill: #833;">0.33 x 0.20</text></svg>

--- a/tests/__snapshots__/testpoint_right.snap.svg
+++ b/tests/__snapshots__/testpoint_right.snap.svg
@@ -1,10 +1,10 @@
-<svg width="150" height="150" viewBox="-0.39 -0.24 0.78 0.48" xmlns="http://www.w3.org/2000/svg"><path d="M-0.4,0 L0,0" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M0.2,-0.2 L0.11322325217648838,-0.18019377358048383 L0.043633703506394034,-0.1246979603717467 L0.005014417563635271,-0.04450418679126288 L0.005014417563635271,0.04450418679126288 L0.043633703506394034,0.1246979603717467 L0.11322325217648838,0.18019377358048383 L0.2,0.2" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <text x="0.25" y="0" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.2375" y="-0.0125" width="0.025" height="0.025" fill="blue" />
+<svg width="150" height="150" viewBox="-0.195 -0.12 0.39 0.24" xmlns="http://www.w3.org/2000/svg"><path d="M-0.2,0 L0,0" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.1,-0.1 L0.05661162608824419,-0.09009688679024191 L0.021816851753197017,-0.06234898018587335 L0.0025072087818176353,-0.02225209339563144 L0.0025072087818176353,0.02225209339563144 L0.021816851753197017,0.06234898018587335 L0.05661162608824419,0.09009688679024191 L0.1,0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <text x="0.125" y="0" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.1125" y="-0.0125" width="0.025" height="0.025" fill="blue" />
 
-    <rect x="-0.42500000000000004" y="-0.025" width="0.05" height="0.05" fill="red" />
-    <text x="-0.44" y="0.09" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+    <rect x="-0.22500000000000003" y="-0.025" width="0.05" height="0.05" fill="red" />
+    <text x="-0.24" y="0.09" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.325" y="-0.2" style="font: 0.05px monospace; fill: #833;">0.65 x 0.40</text>
-<text x="-0.325" y="-0.2" style="font: 0.05px monospace; fill: #833;">0.65 x 0.40</text></svg>
+<text x="-0.1625" y="-0.1" style="font: 0.05px monospace; fill: #833;">0.33 x 0.20</text>
+<text x="-0.1625" y="-0.1" style="font: 0.05px monospace; fill: #833;">0.33 x 0.20</text></svg>

--- a/tests/__snapshots__/testpoint_up.snap.svg
+++ b/tests/__snapshots__/testpoint_up.snap.svg
@@ -1,10 +1,10 @@
-<svg width="150" height="150" viewBox="-0.24 -0.39 0.48 0.78" xmlns="http://www.w3.org/2000/svg"><path d="M-2.4492935982947065e-17,0.4 L0,0" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M-0.2,-0.2 L-0.18019377358048383,-0.11322325217648839 L-0.1246979603717467,-0.04363370350639404 L-0.04450418679126288,-0.005014417563635273 L0.04450418679126288,-0.005014417563635268 L0.1246979603717467,-0.04363370350639403 L0.18019377358048383,-0.11322325217648836 L0.2,-0.2" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <text x="1.5308084989341915e-17" y="-0.25" dx="0" dy="0" text-anchor="middle" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.012499999999999985" y="-0.2625" width="0.025" height="0.025" fill="blue" />
+<svg width="150" height="150" viewBox="-0.12 -0.195 0.24 0.39" xmlns="http://www.w3.org/2000/svg"><path d="M-1.2246467991473533e-17,0.2 L0,0" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.1,-0.1 L-0.09009688679024191,-0.056611626088244195 L-0.06234898018587335,-0.021816851753197017 L-0.02225209339563144,-0.0025072087818176366 L0.02225209339563144,-0.002507208781817634 L0.06234898018587335,-0.021816851753197017 L0.09009688679024191,-0.05661162608824418 L0.1,-0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <text x="7.654042494670958e-18" y="-0.125" dx="0" dy="0" text-anchor="middle" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.006249999999999992" y="-0.13125" width="0.025" height="0.025" fill="blue" />
 
-    <rect x="-0.025000000000000026" y="0.375" width="0.05" height="0.05" fill="red" />
-    <text x="-0.04000000000000003" y="0.49" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+    <rect x="-0.012500000000000013" y="0.1875" width="0.05" height="0.05" fill="red" />
+    <text x="-0.020000000000000014" y="0.245" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
   
 <path d="M 0 -0.025 L 0.025 0 L 0 0.025 L -0.025 0 Z" fill="green" />
-<text x="-0.2" y="-0.325" style="font: 0.05px monospace; fill: #833;">0.40 x 0.65</text>
-<text x="-0.2" y="-0.325" style="font: 0.05px monospace; fill: #833;">0.40 x 0.65</text></svg>
+<text x="-0.1" y="-0.1625" style="font: 0.05px monospace; fill: #833;">0.20 x 0.33</text>
+<text x="-0.1" y="-0.1625" style="font: 0.05px monospace; fill: #833;">0.20 x 0.33</text></svg>


### PR DESCRIPTION
## Summary
- reduce the size of the testpoint symbol by half
- update SVG snapshots accordingly

## Testing
- `bun test` *(fails: Cannot find package 'bun-match-svg')*

------
https://chatgpt.com/codex/tasks/task_e_685ee049037c832888720171bf5b9b64