### PR TITLE
Adjust not_connected line thickness

### DIFF
--- a/assets/generated/not_connected.json
+++ b/assets/generated/not_connected.json
@@ -7,7 +7,8 @@
       { "x": 0.1, "y": 0.1 }
     ],
     "color": "primary",
-    "fill": false
+    "fill": false,
+    "strokeWidth": 0.01
   },
   "diag2": {
     "type": "path",
@@ -16,7 +17,8 @@
       { "x": 0.1, "y": -0.1 }
     ],
     "color": "primary",
-    "fill": false
+    "fill": false,
+    "strokeWidth": 0.01
   },
     "stem": {
       "type": "path",
@@ -25,7 +27,8 @@
         { "x": 0, "y": 0 }
       ],
       "color": "primary",
-      "fill": false
+      "fill": false,
+      "strokeWidth": 0.01
     }
   },
   "texts": {},

--- a/drawing/getSvg.ts
+++ b/drawing/getSvg.ts
@@ -110,7 +110,7 @@ export function getInnerSvg(
           primitive.fill ? mapColor(primitive.color) : "none"
         }" stroke="${mapColor(
           primitive.color,
-        )}" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />`
+        )}" stroke-width="${primitive.strokeWidth ?? 0.02}" stroke-linecap="round" stroke-linejoin="round" />`
       case "text":
         const textElements = createTextElement(primitive, { yUpPositive: true })
         return textElements.text + (debug ? textElements.anchor : "")
@@ -119,7 +119,9 @@ export function getInnerSvg(
           primitive.radius
         }" fill="${primitive.fill ? mapColor(primitive.color) : "none"}" ${
           !primitive.fill
-            ? `stroke="${mapColor(primitive.color)}" stroke-width="0.02"`
+            ? `stroke="${mapColor(primitive.color)}" stroke-width="${
+                primitive.strokeWidth ?? 0.02
+              }"`
             : ""
         } />`
       case "box":

--- a/drawing/types.ts
+++ b/drawing/types.ts
@@ -14,6 +14,7 @@ export interface PathPrimitive {
   fill?: boolean
   points: Point[]
   color: string
+  strokeWidth?: number
   closed?: boolean
 }
 
@@ -33,6 +34,7 @@ export interface CirclePrimitive {
   radius: number
   fill: boolean
   color: string
+  strokeWidth?: number
 }
 
 export interface BoxPrimitive {

--- a/tests/__snapshots__/not_connected_down.snap.svg
+++ b/tests/__snapshots__/not_connected_down.snap.svg
@@ -1,6 +1,6 @@
-<svg width="150" height="150" viewBox="-0.12 -0.18000000000000002 0.24 0.36000000000000004" xmlns="http://www.w3.org/2000/svg"><path d="M-0.1,-0.1 L0.1,0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M0.1,-0.1 L-0.1,0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M-1.2246467991473533e-17,-0.2 L0,0" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+<svg width="150" height="150" viewBox="-0.12 -0.18000000000000002 0.24 0.36000000000000004" xmlns="http://www.w3.org/2000/svg"><path d="M-0.1,-0.1 L0.1,0.1" fill="none" stroke="black" stroke-width="0.01" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.1,-0.1 L-0.1,0.1" fill="none" stroke="black" stroke-width="0.01" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-1.2246467991473533e-17,-0.2 L0,0" fill="none" stroke="black" stroke-width="0.01" stroke-linecap="round" stroke-linejoin="round" />
 
     <rect x="-0.025000000000000015" y="-0.225" width="0.05" height="0.05" fill="red" />
     <text x="-0.040000000000000015" y="-0.11000000000000001" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>

--- a/tests/__snapshots__/not_connected_left.snap.svg
+++ b/tests/__snapshots__/not_connected_left.snap.svg
@@ -1,6 +1,6 @@
-<svg width="150" height="150" viewBox="-0.18000000000000002 -0.12000000000000002 0.36000000000000004 0.24000000000000005" xmlns="http://www.w3.org/2000/svg"><path d="M0.09999999999999999,-0.10000000000000002 L-0.09999999999999999,0.10000000000000002" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M0.10000000000000002,0.09999999999999999 L-0.10000000000000002,-0.09999999999999999" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M0.2,-2.4492935982947065e-17 L0,0" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+<svg width="150" height="150" viewBox="-0.18000000000000002 -0.12000000000000002 0.36000000000000004 0.24000000000000005" xmlns="http://www.w3.org/2000/svg"><path d="M0.09999999999999999,-0.10000000000000002 L-0.09999999999999999,0.10000000000000002" fill="none" stroke="black" stroke-width="0.01" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.10000000000000002,0.09999999999999999 L-0.10000000000000002,-0.09999999999999999" fill="none" stroke="black" stroke-width="0.01" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.2,-2.4492935982947065e-17 L0,0" fill="none" stroke="black" stroke-width="0.01" stroke-linecap="round" stroke-linejoin="round" />
 
     <rect x="0.17500000000000002" y="-0.025000000000000026" width="0.05" height="0.05" fill="red" />
     <text x="0.16" y="0.08999999999999997" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>

--- a/tests/__snapshots__/not_connected_right.snap.svg
+++ b/tests/__snapshots__/not_connected_right.snap.svg
@@ -1,6 +1,6 @@
-<svg width="150" height="150" viewBox="-0.18000000000000002 -0.12 0.36000000000000004 0.24" xmlns="http://www.w3.org/2000/svg"><path d="M-0.1,0.1 L0.1,-0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M-0.1,-0.1 L0.1,0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M-0.2,0 L0,0" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+<svg width="150" height="150" viewBox="-0.18000000000000002 -0.12 0.36000000000000004 0.24" xmlns="http://www.w3.org/2000/svg"><path d="M-0.1,0.1 L0.1,-0.1" fill="none" stroke="black" stroke-width="0.01" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.1,-0.1 L0.1,0.1" fill="none" stroke="black" stroke-width="0.01" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.2,0 L0,0" fill="none" stroke="black" stroke-width="0.01" stroke-linecap="round" stroke-linejoin="round" />
 
     <rect x="-0.225" y="-0.025" width="0.05" height="0.05" fill="red" />
     <text x="-0.24000000000000002" y="0.09" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>

--- a/tests/__snapshots__/not_connected_up.snap.svg
+++ b/tests/__snapshots__/not_connected_up.snap.svg
@@ -1,6 +1,6 @@
-<svg width="150" height="150" viewBox="-0.12 -0.18000000000000002 0.24 0.36000000000000004" xmlns="http://www.w3.org/2000/svg"><path d="M0.1,0.1 L-0.1,-0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M-0.1,0.1 L0.1,-0.1" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M-1.2246467991473533e-17,0.2 L0,0" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+<svg width="150" height="150" viewBox="-0.12 -0.18000000000000002 0.24 0.36000000000000004" xmlns="http://www.w3.org/2000/svg"><path d="M0.1,0.1 L-0.1,-0.1" fill="none" stroke="black" stroke-width="0.01" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.1,0.1 L0.1,-0.1" fill="none" stroke="black" stroke-width="0.01" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-1.2246467991473533e-17,0.2 L0,0" fill="none" stroke="black" stroke-width="0.01" stroke-linecap="round" stroke-linejoin="round" />
 
     <rect x="-0.025000000000000015" y="0.17500000000000002" width="0.05" height="0.05" fill="red" />
     <text x="-0.040000000000000015" y="0.29" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>


### PR DESCRIPTION
## Summary
- allow stroke width to be specified per primitive
- update not_connected symbol to use thinner lines
- update snapshots for not_connected symbol

## Testing
- `bun test` *(fails: Cannot find package 'bun-match-svg')*
- `bun x biome format . --write` *(fails: 403 error due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6862baed10cc83289bc6e52af9e9546a