### PR TITLE
feat: add resonator orientation variations

### DIFF
--- a/generated/symbols-index.ts
+++ b/generated/symbols-index.ts
@@ -202,7 +202,11 @@ import _resistor_down from "./../symbols/resistor_down"
 import _resistor_left from "./../symbols/resistor_left"
 import _resistor_right from "./../symbols/resistor_right"
 import _resistor_up from "./../symbols/resistor_up"
+import _resonator_down from "./../symbols/resonator_down"
 import _resonator_horz from "./../symbols/resonator_horz"
+import _resonator_left from "./../symbols/resonator_left"
+import _resonator_right from "./../symbols/resonator_right"
+import _resonator_up from "./../symbols/resonator_up"
 import _resonator_vert from "./../symbols/resonator_vert"
 import _schottky_diode_down from "./../symbols/schottky_diode_down"
 import _schottky_diode_left from "./../symbols/schottky_diode_left"
@@ -495,7 +499,11 @@ export default {
   "resistor_left": _resistor_left,
   "resistor_right": _resistor_right,
   "resistor_up": _resistor_up,
+  "resonator_down": _resonator_down,
   "resonator_horz": _resonator_horz,
+  "resonator_left": _resonator_left,
+  "resonator_right": _resonator_right,
+  "resonator_up": _resonator_up,
   "resonator_vert": _resonator_vert,
   "schottky_diode_down": _schottky_diode_down,
   "schottky_diode_left": _schottky_diode_left,

--- a/symbols/resonator_down.ts
+++ b/symbols/resonator_down.ts
@@ -1,0 +1,4 @@
+import { rotateSymbol } from "drawing/rotateSymbol"
+import resonator_right from "./resonator_right"
+
+export default rotateSymbol(resonator_right, "down")

--- a/symbols/resonator_left.ts
+++ b/symbols/resonator_left.ts
@@ -1,0 +1,4 @@
+import { rotateSymbol } from "drawing/rotateSymbol"
+import resonator_right from "./resonator_right"
+
+export default rotateSymbol(resonator_right, "left")

--- a/symbols/resonator_right.ts
+++ b/symbols/resonator_right.ts
@@ -1,0 +1,34 @@
+import { defineSymbol } from "drawing/defineSymbol"
+import svgJson from "assets/generated/resonator.json"
+
+const { paths, texts, bounds, refblocks, circles } = svgJson
+
+export default defineSymbol({
+  primitives: [
+    ...Object.values(paths),
+    ...Object.values(circles),
+    // { ...texts.top1, anchor: "middle_left" },
+    // { ...texts.bottom1, anchor: "middle_left" },
+    {
+      type: "text",
+      text: "{REF}",
+      x: 0.01596175000000022,
+      y: -0.5308501500000009,
+      anchor: "middle_top",
+    },
+    {
+      type: "text",
+      text: "{VAL}",
+      x: 0.013116750000000454,
+      y: 0.5408501499999989,
+      anchor: "middle_bottom",
+    },
+  ] as any,
+  ports: [
+    { ...refblocks.left1, labels: ["1"] }, // TODO add more "standard" labels
+    { ...refblocks.right1, labels: ["2"] }, // TODO add more "standard" labels
+    { ...refblocks.right2, labels: ["3"] }, // TODO add more "standard" labels
+  ],
+  size: { width: bounds.width, height: bounds.height },
+  center: { x: bounds.centerX, y: bounds.centerY },
+})

--- a/symbols/resonator_up.ts
+++ b/symbols/resonator_up.ts
@@ -1,0 +1,4 @@
+import { rotateSymbol } from "drawing/rotateSymbol"
+import resonator_right from "./resonator_right"
+
+export default rotateSymbol(resonator_right, "up")

--- a/tests/__snapshots__/resonator_down.snap.svg
+++ b/tests/__snapshots__/resonator_down.snap.svg
@@ -1,0 +1,37 @@
+<svg width="150" height="150" viewBox="-0.6430201799999995 -0.9142730999999977 1.2860403599999997 1.828546199999999" xmlns="http://www.w3.org/2000/svg"><path d="M-0.27995445000000135,0.7635944500000021 L-0.2799544500000014,0.31380285000000196" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.0152477500000018,-0.30101794999999754 L-0.015247750000001828,-0.750809649999998" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.3480486499999994,-0.301017949999998 L-0.27983104999999997,-0.30101794999999754" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.35124514999999906,0.7729788500000013 L0.351245149999999,0.3231872500000016" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.27981925000000063,-0.07279374999999787 L-0.27981925000000063,-0.29833504999999805" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.2798404499999997,0.3311483500000022 L-0.2798404499999997,0.10560705000000205" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.1676584500000008,-0.055820049999998005 L-0.3931997500000005,-0.05582004999999799" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.16768285000000172,0.09396265000000227 L-0.39322415000000144,0.09396265000000228" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.3513701499999978,-0.07296184999999814 L0.3513701499999978,-0.2985031499999983" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.35134895000000055,0.330980250000002 L0.35134895000000055,0.10543895000000178" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.46353094999999944,-0.055988149999998266 L0.23798964999999794,-0.05598814999999825" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.4635065500000003,0.09379455000000156 L0.23796525000000057,0.09379455000000157" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.12563885,0.33153175000000223 L0.3511801499999997,0.3315317500000018" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.2783032500000001,0.33151055000000185 L-0.05276195000000037,0.33151055000000185" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.10866515000000057,0.4436925500000021 L0.10866515000000056,0.2181512500000019" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.041117550000000586,0.44366815000000204 L-0.0411175500000006,0.21812685000000187" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.0716700499999984,0.4423544500000022 L0.07167004999999839,0.216813150000002" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.0025598499999986706,0.4429695500000018 L0.07134914999999822,0.44302145000000215" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.0035468500000025304,0.21634305000000176 L0.07036215000000147,0.21639495000000208" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.0041308500000006585,0.4429537500000019 L-0.004130850000000672,0.2174124500000022" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <text x="-0.5308501499999988" y="0.015961750000001693" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.5433501499999988" y="0.0034617500000016926" width="0.025" height="0.025" fill="blue" />
+    <text x="0.540850150000001" y="0.013116750000001865" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.5283501500000011" y="0.0006167500000018641" width="0.025" height="0.025" fill="blue" />
+
+    <rect x="-0.04115044999999931" y="-0.7916234499999983" width="0.05" height="0.05" fill="red" />
+    <text x="-0.05615044999999931" y="-0.6766234499999982" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    <rect x="-0.30685235000000083" y="0.7322390500000013" width="0.05" height="0.05" fill="red" />
+    <text x="-0.3218523500000008" y="0.8472390500000014" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    <rect x="0.32434725000000136" y="0.7416234500000018" width="0.05" height="0.05" fill="red" />
+    <text x="0.3093472500000014" y="0.856623450000002" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 3.3306690738754696e-16 -0.024999999999998225 L 0.025000000000000334 1.7763568394002505e-15 L 3.3306690738754696e-16 0.025000000000001778 L -0.02499999999999967 1.7763568394002505e-15 Z" fill="green" />
+<text x="-0.5358501499999996" y="-0.7618942500000014" style="font: 0.05px monospace; fill: #833;">1.07 x 1.52</text>
+<text x="-0.5358501499999996" y="-0.7618942500000014" style="font: 0.05px monospace; fill: #833;">1.07 x 1.52</text></svg>

--- a/tests/__snapshots__/resonator_left.snap.svg
+++ b/tests/__snapshots__/resonator_left.snap.svg
@@ -1,0 +1,37 @@
+<svg width="150" height="150" viewBox="-0.9142730999999992 -0.643020179999998 1.828546199999999 1.2860403599999997" xmlns="http://www.w3.org/2000/svg"><path d="M-0.76359445,-0.27995444999999985 L-0.3138028499999999,-0.2799544499999999" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.30101794999999965,-0.015247750000000374 L0.7508096500000001,-0.01524775000000043" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.30101795000000015,0.3480486500000008 L0.3010179499999996,-0.2798310499999986" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.7729788499999992,0.35124515000000056 L-0.3231872499999994,0.3512451500000005" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.07279374999999996,-0.2798192499999992 L0.2983350500000001,-0.27981924999999924" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.33114835000000015,-0.2798404499999982 L-0.10560704999999995,-0.27984044999999824" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.0558200500000001,-0.16765844999999935 L0.05582005000000007,-0.39319974999999907" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09396265000000016,-0.16768285000000027 L-0.09396265000000019,-0.39322415" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.07296185000000026,0.35137014999999927 L0.29850315000000044,0.3513701499999992" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.3309802499999998,0.35134895000000205 L-0.10543894999999966,0.351348950000002" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.0559881500000004,0.4635309500000009 L0.055988150000000375,0.2379896499999994" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.09379454999999942,0.46350655000000174 L-0.09379454999999945,0.23796525000000202" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.3315317500000001,0.12563885000000144 L-0.3315317499999996,0.3511801500000012" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.3315105499999998,-0.2783032499999986 L-0.33151054999999974,-0.052761949999998906" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.44369254999999996,0.10866515000000204 L-0.2181512499999998,0.10866515000000201" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.44366814999999993,-0.041117549999999115 L-0.21812684999999976,-0.04111754999999914" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.44235445000000007,0.07167004999999987 L-0.2168131499999999,0.07167004999999985" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.4429695499999997,-0.0025598499999972004 L-0.44302145000000004,0.0713491499999997" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.21634304999999965,-0.003546850000001074 L-0.21639494999999997,0.07036215000000293" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.4429537499999998,-0.004130849999999187 L-0.2174124500000001,-0.004130849999999215" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <text x="-0.01596174999999962" y="-0.5308501499999974" dx="0" dy="0" text-anchor="middle" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="-0.02846174999999962" y="-0.5433501499999973" width="0.025" height="0.025" fill="blue" />
+    <text x="-0.013116749999999722" y="0.5408501500000025" dx="0" dy="0.07500000000000001" text-anchor="middle" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.025616749999999723" y="0.5283501500000025" width="0.025" height="0.025" fill="blue" />
+
+    <rect x="0.7416234500000004" y="-0.04115044999999791" width="0.05" height="0.05" fill="red" />
+    <text x="0.7266234500000004" y="0.0738495500000021" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    <rect x="-0.7822390499999993" y="-0.30685234999999933" width="0.05" height="0.05" fill="red" />
+    <text x="-0.7972390499999993" y="-0.1918523499999993" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    <rect x="-0.7916234499999998" y="0.32434725000000286" width="0.05" height="0.05" fill="red" />
+    <text x="-0.8066234499999998" y="0.43934725000000285" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 3.3306690738754696e-16 -0.024999999999998225 L 0.025000000000000334 1.7763568394002505e-15 L 3.3306690738754696e-16 0.025000000000001778 L -0.02499999999999967 1.7763568394002505e-15 Z" fill="green" />
+<text x="-0.7618942499999993" y="-0.5358501500000017" style="font: 0.05px monospace; fill: #833;">1.52 x 1.07</text>
+<text x="-0.7618942499999993" y="-0.5358501500000017" style="font: 0.05px monospace; fill: #833;">1.52 x 1.07</text></svg>

--- a/tests/__snapshots__/resonator_right.snap.svg
+++ b/tests/__snapshots__/resonator_right.snap.svg
@@ -1,0 +1,37 @@
+<svg width="150" height="150" viewBox="-0.9537382691999997 -0.643020179999998 1.9074765384 1.2860403599999997" xmlns="http://www.w3.org/2000/svg"><path d="M0.7635944500000007,0.2799544500000035 L0.3138028500000005,0.2799544500000035" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.301017949999999,0.01524775000000389 L-0.7508096499999994,0.01524775000000389" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.3010179499999994,-0.3480486499999973 L-0.301017949999999,0.2798310500000021" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.7729788499999999,-0.3512451499999969 L0.32318725000000015,-0.3512451499999969" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.07279374999999932,0.27981925000000274 L-0.2983350499999995,0.27981925000000274" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.33114835000000076,0.2798404500000018 L0.10560705000000059,0.2798404500000018" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.055820049999999455,0.1676584500000029 L-0.055820049999999455,0.3931997500000026" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09396265000000081,0.16768285000000382 L0.09396265000000081,0.39322415000000355" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.07296184999999955,-0.3513701499999957 L-0.2985031499999997,-0.3513701499999957" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.33098025000000053,-0.35134894999999844 L0.10543895000000036,-0.35134894999999844" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.05598814999999968,-0.46353094999999733 L-0.05598814999999968,-0.23798964999999583" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.09379455000000014,-0.4635065499999982 L0.09379455000000014,-0.23796524999999846" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.3315317500000008,-0.12563884999999786 L0.33153175000000035,-0.3511801499999976" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.3315105500000004,0.2783032500000022 L0.3315105500000004,0.0527619500000025" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.44369255000000063,-0.10866514999999843 L0.21815125000000046,-0.10866514999999843" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.4436681500000006,0.04111755000000272 L0.21812685000000043,0.04111755000000272" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.44235445000000073,-0.07167004999999627 L0.21681315000000057,-0.07167004999999627" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.4429695500000004,0.0025598500000008073 L0.4430214500000007,-0.07134914999999609" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.21634305000000031,0.0035468500000046532 L0.21639495000000064,-0.07036214999999935" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.4429537500000005,0.004130850000002795 L0.21741245000000076,0.004130850000002795" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <text x="0.01596175000000022" y="0.5308501500000009" dx="0" dy="0.07500000000000001" text-anchor="middle" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.003461750000000218" y="0.518350150000001" width="0.025" height="0.025" fill="blue" />
+    <text x="0.013116750000000454" y="-0.5408501499999989" dx="0" dy="0" text-anchor="middle" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="0.0006167500000004537" y="-0.5533501499999989" width="0.025" height="0.025" fill="blue" />
+
+    <rect x="-0.7916234499999998" y="-0.00884954999999863" width="0.05" height="0.05" fill="red" />
+    <text x="-0.8066234499999998" y="0.10615045000000137" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    <rect x="0.7322390499999999" y="0.25685235000000295" width="0.05" height="0.05" fill="red" />
+    <text x="0.7172390499999999" y="0.37185235000000294" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    <rect x="0.7416234500000004" y="-0.37434724999999924" width="0.05" height="0.05" fill="red" />
+    <text x="0.7266234500000004" y="-0.25934724999999925" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 3.3306690738754696e-16 -0.024999999999998225 L 0.025000000000000334 1.7763568394002505e-15 L 3.3306690738754696e-16 0.025000000000001778 L -0.02499999999999967 1.7763568394002505e-15 Z" fill="green" />
+<text x="-0.7947818909999997" y="-0.5358501500000017" style="font: 0.05px monospace; fill: #833;">1.59 x 1.07</text>
+<text x="-0.7947818909999997" y="-0.5358501500000017" style="font: 0.05px monospace; fill: #833;">1.59 x 1.07</text></svg>

--- a/tests/__snapshots__/resonator_up.snap.svg
+++ b/tests/__snapshots__/resonator_up.snap.svg
@@ -1,0 +1,37 @@
+<svg width="150" height="150" viewBox="-0.6430201799999995 -0.9142730999999977 1.2860403599999997 1.828546199999999" xmlns="http://www.w3.org/2000/svg"><path d="M0.27995445000000213,-0.7635944499999986 L0.2799544500000021,-0.3138028499999984" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.015247750000002428,0.3010179500000011 L0.0152477500000024,0.7508096500000015" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.34804864999999874,0.30101795000000153 L0.27983105000000064,0.3010179500000011" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.3512451499999983,-0.7729788499999978 L-0.35124514999999834,-0.32318724999999804" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.2798192500000013,0.07279375000000145 L0.2798192500000013,0.2983350500000016" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.27984045000000035,-0.33114834999999865 L0.27984045000000035,-0.10560704999999847" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.16765845000000146,0.05582005000000157 L0.3931997500000012,0.055820050000001585" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.16768285000000238,-0.09396264999999869 L0.3932241500000021,-0.09396264999999868" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.35137014999999716,0.07296185000000163 L-0.35137014999999716,0.2985031500000018" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.3513489499999999,-0.3309802499999984 L-0.3513489499999999,-0.10543894999999828" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.4635309499999988,0.05598815000000176 L-0.23798964999999728,0.05598815000000178" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.46350654999999963,-0.09379454999999806 L-0.2379652499999999,-0.09379454999999805" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.12563884999999927,-0.3315317499999987 L-0.351180149999999,-0.33153174999999824" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.2783032500000008,-0.3315105499999983 L0.05276195000000108,-0.3315105499999983" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.10866514999999985,-0.4436925499999985 L-0.10866514999999986,-0.21815124999999835" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.04111755000000131,-0.4436681499999985 L0.04111755000000129,-0.21812684999999832" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-0.07167004999999768,-0.4423544499999986 L-0.0716700499999977,-0.21681314999999846" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.0025598499999993913,-0.44296954999999827 L-0.0713491499999975,-0.4430214499999986" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.0035468500000032234,-0.2163430499999982 L-0.07036215000000078,-0.21639494999999853" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0.004130850000001378,-0.44295374999999837 L0.0041308500000013645,-0.21741244999999865" fill="none" stroke="black" stroke-width="0.02" stroke-linecap="round" stroke-linejoin="round" />
+    <text x="0.5308501499999995" y="-0.015961749999998078" dx="0" dy="0.037500000000000006" text-anchor="start" style="font: 0.1px monospace; fill: black">{REF}</text><rect x="0.5183501499999995" y="-0.02846174999999808" width="0.025" height="0.025" fill="blue" />
+    <text x="-0.5408501500000004" y="-0.013116749999998378" dx="0" dy="0.037500000000000006" text-anchor="end" style="font: 0.1px monospace; fill: black">{VAL}</text><rect x="-0.5533501500000003" y="-0.025616749999998377" width="0.025" height="0.025" fill="blue" />
+
+    <rect x="-0.008849550000000123" y="0.7416234500000018" width="0.05" height="0.05" fill="red" />
+    <text x="-0.023849550000000122" y="0.856623450000002" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">1</text>
+  
+    
+    <rect x="0.25685235000000156" y="-0.7822390499999978" width="0.05" height="0.05" fill="red" />
+    <text x="0.24185235000000158" y="-0.6672390499999977" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">2</text>
+  
+    
+    <rect x="-0.37434725000000063" y="-0.7916234499999983" width="0.05" height="0.05" fill="red" />
+    <text x="-0.3893472500000006" y="-0.6766234499999982" text-anchor="middle" style="font: 0.08px monospace; fill: #833;">3</text>
+  
+<path d="M 3.3306690738754696e-16 -0.024999999999998225 L 0.025000000000000334 1.7763568394002505e-15 L 3.3306690738754696e-16 0.025000000000001778 L -0.02499999999999967 1.7763568394002505e-15 Z" fill="green" />
+<text x="-0.5358501499999996" y="-0.7618942500000014" style="font: 0.05px monospace; fill: #833;">1.07 x 1.52</text>
+<text x="-0.5358501499999996" y="-0.7618942500000014" style="font: 0.05px monospace; fill: #833;">1.07 x 1.52</text></svg>


### PR DESCRIPTION
## Summary
- add left, right, up, and down variations for resonator symbol
- update generated symbols index and snapshots

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_689b44b4a3748328a88a079996e2ddb8